### PR TITLE
Fix missing json import

### DIFF
--- a/dune_collector.py
+++ b/dune_collector.py
@@ -4,6 +4,7 @@ import logging
 import sqlite3
 import requests
 import time
+import json
 from typing import Dict, List, Any
 
 from config import get_config


### PR DESCRIPTION
## Summary
- import `json` in dune_collector so that `json.dumps` works

## Testing
- `python -m py_compile dune_collector.py`


------
https://chatgpt.com/codex/tasks/task_e_6883e1b5c66c832bb9fb6eb2b315a55f