### PR TITLE
Use last trade timestamp from Polygon snapshot

### DIFF
--- a/alpha_polygon_analyzer.py
+++ b/alpha_polygon_analyzer.py
@@ -79,10 +79,12 @@ class AlphaPolygonAnalyzer:
                         )
                         conn.commit()
                 if snap.get('ticker'):
+                    # store Polygon last trade timestamp and price
+                    trade = snap['ticker'].get('lastTrade', {})
                     with sqlite3.connect(self.db_path) as conn:
                         conn.execute(
                             "INSERT OR REPLACE INTO prices VALUES (?, ?, ?, ?)",
-                            (sym, snap['status'], snap['ticker'].get('lastTrade', {}).get('p', 0), 'polygon')
+                            (sym, trade.get('t'), trade.get('p', 0), 'polygon')
                         )
                         conn.commit()
                 await asyncio.sleep(1)


### PR DESCRIPTION
## Summary
- store Polygon last trade timestamp and price instead of snapshot status
- clarify comment about stored values

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6883e1ba8a4c832bba8f83e42212033f