### PR TITLE
Add DB path config and setup utility

### DIFF
--- a/alpha_polygon_analyzer.py
+++ b/alpha_polygon_analyzer.py
@@ -41,7 +41,7 @@ class PolygonClient:
 
 
 class AlphaPolygonAnalyzer:
-    def __init__(self, db_path: str = "alpha_polygon.db"):
+    def __init__(self, db_path: str = get_config("DB_PATH", "opus.db")):
         self.av_key = get_config('ALPHA_VANTAGE_KEY', '')
         self.poly_key = get_config('POLYGON_KEY', '')
         self.db_path = db_path

--- a/bigquery_collector.py
+++ b/bigquery_collector.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class BigQueryDataCollector:
-    def __init__(self, db_path: str = "bigquery_data.db", project_id: str = None):
+    def __init__(self, db_path: str = get_config("DB_PATH", "opus.db"), project_id: str = None):
         self.db_path = db_path
         self.project_id = project_id or get_config('GOOGLE_CLOUD_PROJECT')
         self.client = bigquery.Client(project=self.project_id)

--- a/ccxt_collector.py
+++ b/ccxt_collector.py
@@ -4,11 +4,12 @@ import sqlite3
 import logging
 from typing import List
 import ccxt.async_support as ccxt
+from config import get_config
 
 logger = logging.getLogger(__name__)
 
 class CCXTDataCollector:
-    def __init__(self, db_path: str = 'crypto_data.db'):
+    def __init__(self, db_path: str = get_config("DB_PATH", "opus.db")):
         self.db_path = db_path
         self.exchange = ccxt.binance({'enableRateLimit': True})
         self.init_db()

--- a/config.py
+++ b/config.py
@@ -1,5 +1,12 @@
 import os
 
-def get_config(key: str, default: str = None) -> str:
+_DEFAULTS = {
+    "DB_PATH": "opus.db",
+}
+
+
+def get_config(key: str, default: str | None = None) -> str:
     """Retrieve configuration value from environment variables."""
+    if default is None:
+        default = _DEFAULTS.get(key)
     return os.getenv(key, default)

--- a/dune_collector.py
+++ b/dune_collector.py
@@ -17,7 +17,7 @@ class DuneAnalyticsCollector:
 
     BASE_URL = "https://api.dune.com/api/v1"
 
-    def __init__(self, db_path: str = "dune_data.db"):
+    def __init__(self, db_path: str = get_config("DB_PATH", "opus.db")):
         self.api_key = get_config("DUNE_API_KEY", "")
         self.db_path = db_path
         self.init_db()

--- a/fred_data_collector.py
+++ b/fred_data_collector.py
@@ -24,7 +24,7 @@ class FREDDataCollector:
         "DGS10": "10-Year Treasury Rate",
     }
 
-    def __init__(self, db_path: str = "fred_data.db"):
+    def __init__(self, db_path: str = get_config("DB_PATH", "opus.db")):
         self.api_key = get_config("FRED_API_KEY", "")
         self.db_path = db_path
         self.conn: Optional[sqlite3.Connection] = None

--- a/setup_database.py
+++ b/setup_database.py
@@ -1,0 +1,21 @@
+import logging
+import sqlite3
+from pathlib import Path
+
+from config import get_config
+from database_optimizer import setup_database_optimization
+
+
+def initialize_database(db_path: str):
+    schema_file = Path(__file__).with_name("database_schema.sql")
+    if schema_file.exists():
+        with sqlite3.connect(db_path) as conn, open(schema_file, "r") as f:
+            conn.executescript(f.read())
+            conn.commit()
+    setup_database_optimization(db_path)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    db = get_config("DB_PATH", "opus.db")
+    initialize_database(db)

--- a/telegram_alerts.py
+++ b/telegram_alerts.py
@@ -18,7 +18,7 @@ class Alert:
     severity: str = 'info'
 
 class TelegramAlertSystem:
-    def __init__(self, db_path: str = 'alerts.db'):
+    def __init__(self, db_path: str = get_config("DB_PATH", "opus.db")):
         self.token = get_config('TELEGRAM_BOT_TOKEN')
         self.chat_id = get_config('TELEGRAM_CHAT_ID')
         self.bot = Bot(self.token)


### PR DESCRIPTION
## Summary
- provide default `DB_PATH` in `config.get_config`
- use `get_config("DB_PATH", "opus.db")` for collector defaults
- add `setup_database.py` for initializing the SQLite database

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68845c050e54832b8eb4a311642b6195