### PR TITLE
Switch to aiosqlite in async modules

### DIFF
--- a/ccxt_collector.py
+++ b/ccxt_collector.py
@@ -1,6 +1,6 @@
 # Simplified CCXT data collector
 import asyncio
-import sqlite3
+import aiosqlite
 import logging
 from typing import List
 import ccxt.async_support as ccxt
@@ -11,11 +11,10 @@ class CCXTDataCollector:
     def __init__(self, db_path: str = 'crypto_data.db'):
         self.db_path = db_path
         self.exchange = ccxt.binance({'enableRateLimit': True})
-        self.init_db()
 
-    def init_db(self):
-        with sqlite3.connect(self.db_path) as conn:
-            conn.execute(
+    async def init_db(self):
+        async with aiosqlite.connect(self.db_path) as conn:
+            await conn.execute(
                 """CREATE TABLE IF NOT EXISTS ohlcv (
                     symbol TEXT,
                     timestamp INTEGER,
@@ -27,17 +26,18 @@ class CCXTDataCollector:
                     PRIMARY KEY (symbol, timestamp)
                 )"""
             )
-            conn.commit()
+            await conn.commit()
 
     async def fetch_ohlcv(self, symbol: str):
+        await self.init_db()
         data = await self.exchange.fetch_ohlcv(symbol, '1h', limit=24)
-        with sqlite3.connect(self.db_path) as conn:
+        async with aiosqlite.connect(self.db_path) as conn:
             for candle in data:
-                conn.execute(
+                await conn.execute(
                     'INSERT OR REPLACE INTO ohlcv VALUES (?, ?, ?, ?, ?, ?, ?)',
                     (symbol, candle[0], candle[1], candle[2], candle[3], candle[4], candle[5])
                 )
-            conn.commit()
+            await conn.commit()
 
     async def close(self):
         await self.exchange.close()

--- a/fred_data_collector.py
+++ b/fred_data_collector.py
@@ -1,7 +1,7 @@
 import asyncio
 import datetime
 import logging
-import sqlite3
+import aiosqlite
 from typing import List, Dict, Optional
 import aiohttp
 
@@ -27,13 +27,11 @@ class FREDDataCollector:
     def __init__(self, db_path: str = "fred_data.db"):
         self.api_key = get_config("FRED_API_KEY", "")
         self.db_path = db_path
-        self.conn: Optional[sqlite3.Connection] = None
-        self.init_db()
 
-    def init_db(self):
+    async def init_db(self):
         """Create tables if they do not exist."""
-        with sqlite3.connect(self.db_path) as conn:
-            conn.execute(
+        async with aiosqlite.connect(self.db_path) as conn:
+            await conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS fred_series (
                     series_id TEXT PRIMARY KEY,
@@ -41,7 +39,7 @@ class FREDDataCollector:
                 )
                 """
             )
-            conn.execute(
+            await conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS fred_observations (
                     series_id TEXT,
@@ -51,7 +49,7 @@ class FREDDataCollector:
                 )
                 """
             )
-            conn.commit()
+            await conn.commit()
 
     async def fetch_series_info(self, session: aiohttp.ClientSession, series_id: str) -> Dict:
         params = {
@@ -79,17 +77,18 @@ class FREDDataCollector:
             data = await resp.json()
             return data.get("observations", [])
 
-    def _store_series_info(self, series_id: str, info: Dict):
-        if not info or not self.conn:
+    async def _store_series_info(self, series_id: str, info: Dict):
+        if not info:
             return
-        self.conn.execute(
-            "INSERT OR REPLACE INTO fred_series (series_id, title) VALUES (?, ?)",
-            (series_id, info.get("title")),
-        )
-        self.conn.commit()
+        async with aiosqlite.connect(self.db_path) as conn:
+            await conn.execute(
+                "INSERT OR REPLACE INTO fred_series (series_id, title) VALUES (?, ?)",
+                (series_id, info.get("title")),
+            )
+            await conn.commit()
 
-    def _store_observations(self, series_id: str, observations: List[Dict]):
-        if not observations or not self.conn:
+    async def _store_observations(self, series_id: str, observations: List[Dict]):
+        if not observations:
             return
         rows = []
         for obs in observations:
@@ -104,22 +103,24 @@ class FREDDataCollector:
             rows.append((series_id, date, val))
 
         if rows:
-            self.conn.executemany(
-                "INSERT OR REPLACE INTO fred_observations (series_id, date, value) VALUES (?, ?, ?)",
-                rows,
-            )
-            self.conn.commit()
+            async with aiosqlite.connect(self.db_path) as conn:
+                await conn.executemany(
+                    "INSERT OR REPLACE INTO fred_observations (series_id, date, value) VALUES (?, ?, ?)",
+                    rows,
+                )
+                await conn.commit()
 
     async def fetch_all_series_data(self, series_ids: Optional[List[str]] = None):
         if series_ids is None:
             series_ids = list(self.SERIES.keys())
+        await self.init_db()
         async with aiohttp.ClientSession() as session:
             for sid in series_ids:
                 logger.info(f"Fetching {sid}")
                 info = await self.fetch_series_info(session, sid)
-                self._store_series_info(sid, info)
+                await self._store_series_info(sid, info)
                 observations = await self.fetch_observations(session, sid)
-                self._store_observations(sid, observations)
+                await self._store_observations(sid, observations)
                 await asyncio.sleep(1)  # basic rate limiting
         logger.info("Completed FRED data fetch")
 


### PR DESCRIPTION
## Summary
- migrate async modules from `sqlite3` to `aiosqlite`
- use `async with aiosqlite.connect()` and `await` database calls

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68845c068d6c832ba85f58c56813b321