### PR TITLE
Fix async FRED storage

### DIFF
--- a/fred_data_collector.py
+++ b/fred_data_collector.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import logging
+import sqlite3
 import aiosqlite
 from typing import List, Dict, Optional
 import aiohttp
@@ -116,15 +117,13 @@ class FREDDataCollector:
         await self.init_db()
         async with aiohttp.ClientSession() as session:
             with sqlite3.connect(self.db_path) as conn:
-                self.conn = conn
                 for sid in series_ids:
                     logger.info(f"Fetching {sid}")
                     info = await self.fetch_series_info(session, sid)
-                    self._store_series_info(sid, info)
+                    await self._store_series_info(sid, info)
                     observations = await self.fetch_observations(session, sid)
-                    self._store_observations(sid, observations)
+                    await self._store_observations(sid, observations)
                     await asyncio.sleep(1)  # basic rate limiting
-                self.conn = None
         logger.info("Completed FRED data fetch")
 
 


### PR DESCRIPTION
## Summary
- add missing `sqlite3` import
- await storing operations in `fetch_all_series_data`
- drop unused `self.conn` attribute

## Testing
- `python -m py_compile fred_data_collector.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6884ee6cebfc832b883f7b6d13b8790e