### PR TITLE
Fix Telegram initialization when credentials missing

### DIFF
--- a/telegram_alerts.py
+++ b/telegram_alerts.py
@@ -22,8 +22,16 @@ class TelegramAlertSystem:
         self.token = get_config('TELEGRAM_BOT_TOKEN')
         self.chat_id = get_config('TELEGRAM_CHAT_ID')
         self.bot = None
-        if not self.token or not self.chat_id:
-            logger.warning("Telegram credentials not provided; alerts disabled")
+        missing = []
+        if not self.token:
+            missing.append("TELEGRAM_BOT_TOKEN")
+        if not self.chat_id:
+            missing.append("TELEGRAM_CHAT_ID")
+
+        if missing:
+            logger.warning(
+                f"Missing {', '.join(missing)}; telegram alerts disabled"
+            )
         else:
             try:
                 self.bot = Bot(self.token)


### PR DESCRIPTION
## Summary
- check for TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID individually
- log which credential is missing and skip Telegram bot setup

## Testing
- `python -m py_compile telegram_alerts.py`


------
https://chatgpt.com/codex/tasks/task_e_68856c9334ec832bb01f2452412c31e8