### PR TITLE
Fix ccxt collector integration

### DIFF
--- a/enhanced_coin_manager.py
+++ b/enhanced_coin_manager.py
@@ -505,8 +505,8 @@ async def setup_enhanced_coin_tracking(db_path: str, ccxt_collector) -> CoinMana
     """Set up enhanced coin tracking with auto-discovery."""
     manager = CoinManager(db_path)
     
-    if ccxt_collector and ccxt_collector.exchanges:
-        new_coins = await manager.discover_new_coins(ccxt_collector.exchanges)
+    if ccxt_collector and getattr(ccxt_collector, "exchange", None):
+        new_coins = await manager.discover_new_coins({"default": ccxt_collector.exchange})
         manager.auto_add_trending(min_volume=5_000_000)
     
     return manager

--- a/tests/test_setup_enhanced_coin_tracking.py
+++ b/tests/test_setup_enhanced_coin_tracking.py
@@ -1,0 +1,54 @@
+import asyncio
+import unittest
+from unittest.mock import patch
+import sys
+import types
+
+# Stub minimal telegram module before importing enhanced_coin_manager
+telegram_stub = types.ModuleType("telegram")
+telegram_stub.InlineKeyboardButton = object
+telegram_stub.InlineKeyboardMarkup = object
+telegram_stub.ParseMode = object
+telegram_ext_stub = types.ModuleType("telegram.ext")
+telegram_ext_stub.CommandHandler = object
+telegram_ext_stub.CallbackQueryHandler = object
+sys.modules.setdefault("telegram", telegram_stub)
+sys.modules.setdefault("telegram.ext", telegram_ext_stub)
+
+import enhanced_coin_manager
+
+class DummyExchange:
+    def __init__(self):
+        self.markets = {}
+        self.symbols = []
+    async def fetch_ticker(self, pair):
+        return {}
+
+class DummyCollector:
+    def __init__(self):
+        self.exchange = DummyExchange()
+
+class DummyManager:
+    def __init__(self, db_path):
+        self.db_path = db_path
+        self.called = False
+        self.exchanges = None
+    async def discover_new_coins(self, exchanges):
+        self.called = True
+        self.exchanges = exchanges
+        return []
+    def auto_add_trending(self, min_volume=0, min_exchanges=2):
+        pass
+
+class SetupTest(unittest.TestCase):
+    def test_setup_uses_exchange_attribute(self):
+        collector = DummyCollector()
+        with patch.object(enhanced_coin_manager, 'CoinManager', DummyManager):
+            manager = asyncio.run(
+                enhanced_coin_manager.setup_enhanced_coin_tracking('test.db', collector)
+            )
+        self.assertTrue(manager.called)
+        self.assertIsInstance(manager.exchanges, dict)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- reference `ccxt_collector.exchange` in enhanced coin manager
- test setup_enhanced_coin_tracking works with single exchange

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_688647416bd4832bb0c1539c5a0c0070