### PR TITLE
Pin telegram bot version

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ relies mostly on free API tiers.
 Create a Python environment (conda or `venv`) and install the
 dependencies listed in `requirements.txt`:
 
+> **Note**: The Telegram examples require `python-telegram-bot` version
+> `13.x`. This is pinned in `requirements.txt` to ensure compatibility
+> with the existing code.
+
 ```bash
 conda create -n opus python=3.10
 conda activate opus
@@ -93,6 +97,10 @@ conda create -n opus4 python=3.10
 conda activate opus4
 pip install -r requirements.txt
 ```
+
+The Telegram utilities depend on `python-telegram-bot` 13.x. Newer
+versions introduce a breaking API change, so the dependency is pinned in
+`requirements.txt`.
 
 2. Set the required API keys as environment variables before running:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ requests
 pandas
 google-cloud-bigquery
 ccxt
-python-telegram-bot
+python-telegram-bot~=13.0
+urllib3<2
 solana
 solders
 numpy


### PR DESCRIPTION
## Summary
- pin python-telegram-bot to the 13.x release line
- document the version requirement in the README
- note the pinned version during install

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
import telegram, ccxt, google.cloud.bigquery, urllib3
print('versions:', telegram.__version__, urllib3.__version__)
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_688647410ad8832b88be46c7552ebac7